### PR TITLE
Fix install for tools that are substrings of other tools

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -122,6 +122,9 @@ defineEnvironment()
 
   # Use /bin/cat as the pager in case xlclang help is displayed, we don't want to wait for input
   export PAGER=/bin/cat
+
+  # Set a default umask of full permissions to owner and group.
+  umask 0002
 }
 
 #

--- a/bin/lib/zopen-download
+++ b/bin/lib/zopen-download
@@ -481,7 +481,7 @@ else
     printVerbose "Stripping any version (%), tag (#) or port suffixes"
     toolrepo=$(echo "$chosenRepo" | sed -e 's#%.*##' -e 's#=.*##' -e 's#.*port##')
     printVerbose "Adding prefix and 'port' suffix" # quicker than testing for presence!
-    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 ~ toolrepo {print}') 
+    toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 == toolrepo {print}') 
     if [ "$toolfound" = "$toolrepo" ]; then
       printVerbose "Adding '$chosenRepo' to the install queue"
       installArray="$installArray $chosenRepo"


### PR DESCRIPTION
Fixes issue `zopen install make` as found by @MikeFultonDev .

```
toolfound=$(echo "${repo_results}" | awk -vtoolrepo="$toolrepo" '$0 ~ toolrepo {print}')
```
This will find cmake first and cause the resulting check to file. Changing to == instead. I'm not sure if this has any other consequences, @DevonianTeuchter 

Also sets the default umask to 0002 to avoid permission issues during copying, re: https://github.com/DevonianTeuchter/meta/issues/42