### PR TITLE
Upgrades within releaseline and query updates

### DIFF
--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -15,6 +15,14 @@ cleanupFunction() {
 }
 trap "cleanupFunction" EXIT INT TERM QUIT HUP
 
+validateReleaseLine(){
+  echo "$1" | awk '
+    toupper($1)=="DEV"    {print toupper($0)}
+    toupper($1)=="STABLE" {print toupper($0)}
+                          { print ""}
+  '
+}
+
 defineANSI() 
 {
   # Standard tty codes
@@ -356,7 +364,8 @@ unsymlinkFromSystem(){
       filenames=""
       while read filetounlink; do
         tid=$(( tid + 1 ))
-        filenames="$filenames\n$filetounlink"
+        filetounlink=$(echo "$filetounlink" | sed 's/\(.*\).symbolic.*/\1/')
+        filenames=$(/bin/printf "%s\n%s" "$filenames" "$filetounlink")
         if [ "$(( tid % threshold ))" -eq 0 ]; then
           deletethread "$filenames" "$tempDirFile" &
           printVerbose "Started delete thread: $!"
@@ -398,7 +407,6 @@ deletetask () {
     tempDirFile="$1"
     filename="$2"
     [ -z "$filename" ] && return 0
-    filename=$(echo "$filename" | sed 's/\(.*\).symbolic.*/\1/')
     filename="$ZOPEN_ROOTFS/$filename"
     if [ -d "$filename" ]; then
         # Add to the queue for checking once files are gone if unique
@@ -414,7 +422,7 @@ deletetask () {
         rm -f "$filename" >/dev/null 2>&1
       fi
     else 
-      echo "Unprocessable file: $filename" >> "$tempTrash" 
+      echo "Unprocessable file: '$filename'" >> "$tempTrash" 
     fi
 }
 

--- a/bin/lib/common.inc
+++ b/bin/lib/common.inc
@@ -23,6 +23,24 @@ validateReleaseLine(){
   '
 }
 
+# Attempt to fully dereference a symlink without any bashisms or arcane set logic
+# using some simplistic (recursive!) logic
+deref(){
+  testpath="$1"
+  if [ -L "$testpath" ]; then
+    child=$(basename "$testpath")
+    symlink=$(ls -l "$testpath" | sed 's/.*-> \(.*\)/\1/')
+    parent=$(dirname "$testpath")
+    relpath="$parent/$symlink"
+    relparent=$(dirname "$relpath")
+    abspath=$(cd "$relparent" && pwd -P)
+    testpath="$abspath/$child"
+    deref "$testpath"
+  else
+    [ -n "$testpath" ] && echo "$testpath" && unset testpath
+  fi
+}
+
 defineANSI() 
 {
   # Standard tty codes
@@ -149,7 +167,7 @@ mutexReq(){
   mypid=$(exec sh -c 'echo $PPID')
   if [ -e "$mutex" ]; then
     lockedpid=$(cat $mutex)
-    { [ ! "$lockedpid" = "$mypid" ] && [ ! "$lockedpid" = "$PPID" ]; } && echo "Aborting, Process '$lockedpid' holds the '$2' lock: '$mutex'" && exit -1
+    { [ ! "$lockedpid" = "$mypid" ] && [ ! "$lockedpid" = "$PPID" ]; } && kill -0 "$lockedpid" 2>/dev/null && echo "Aborting, Active process '$lockedpid' holds the '$2' lock: '$mutex'" && exit -1
   fi
   addCleanupTrapCmd "rm -rf $mutex"
   echo "$mypid" > $mutex

--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -22,6 +22,7 @@ printSyntax()
   echo "  --re-init: re-initialize a previous installation (if present).  Re-initializing over a previous installation will re-use existing package structures and configurations." >&2
   echo "  --clone: clones the current installation to a different location" >&2
   echo "  --append-to-profile: appends sourcing of .zopen-config to .profile" >&2
+  echo "  --releaseline-dev: whether to globally enable Development packages" >&2 
   echo "  -v: run in verbose mode" >&2
   echo "  -?|-h|--help: display help" >&2
 }
@@ -32,6 +33,7 @@ verbose=false
 reinitExisting=false
 clone=false
 appendToProfile=false
+releaselineDev=false
 fslayout="usrlclz"
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -47,6 +49,9 @@ while [ $# -gt 0 ]; do
       ;;
     "--append-to-profile" )
       appendToProfile=true
+      ;;
+    "--releaseline-dev" )
+      releaselineDev=true
       ;;
     "-h" | "--h" | "-help" | "--help" | "-?" | "-syntax")
       printSyntax "${args}"
@@ -355,6 +360,15 @@ else
   # Generate any system values that can be user changed
   echo "15" > "$rootfs/etc/zopen/rm_fileprocs"
 
+  if $releaselineDev; then
+    releaseLine="DEV"
+    printInfo "- Configured zopen to use development (DEV) releaseline packages where available" 
+  else
+    releaseLine="STABLE"
+    printInfo "- Configured zopen to use stable releaseline packages"
+  fi
+  echo "$releaseLine" > "$rootfs/etc/zopen/releaseline"
+
   printInfo "- Check for shipped curl pax"
   curlpax="packages/curl-8.1.2.20230707_145137.zos.pax.Z"
 
@@ -430,7 +444,7 @@ else
   printInfo "- Sourcing environment"
   . "$configFile"
   printInfo "- Using bootstrapped curl and jq to install latest release of itself (if available)"
-  curlInstall=$(runAndLog "${utildir}/zopen-install curl jq")
+  curlInstall=$(runAndLog "${utildir}/zopen-install -y curl jq")
   curlInstall=$?
   [ $curlInstall -ne 0 ] && printError "Unable to install curl and jq; see previous errors and retry the initilisation using the '--re-init' parameter"
   . "$configFile"

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -70,7 +70,8 @@ handlePackageInstall(){
   fi
 
   originalFileVersion=""
-  printVerbose "Checking for meta file at: ${rootInstallDir}/${name}/.releaseinfo"
+  printVerbose "Checking for meta files in '${rootInstallDir}/${name}'"
+  printVerbose "Finding version/release information"
   if [ -e "${rootInstallDir}/${name}/.releaseinfo" ]; then
     originalFileVersion=$(cat "${rootInstallDir}/${name}/.releaseinfo")
     printVerbose "Found originalFileVersion=$originalFileVersion (port is already installed)"
@@ -81,13 +82,20 @@ handlePackageInstall(){
     printVerbose "Could not detect existing installation at ${rootInstallDir}/${name}"
   fi
 
+  printVerbose "Finding releaseline information"
+  installedReleaseLine=""
+  if [ -e "${rootInstallDir}/${name}/.releaseline" ]; then
+    installedReleaseLine=$(cat "${rootInstallDir}/${name}/.releaseline")
+    printVerbose "Installed product from releaseline: $installedReleaseLine"
+  else
+    printVerbose "No current releaseline for package"
+  fi
+  
+  releasemetadata=""
   downloadURL=""
-  if [ ! -z "$releaseLine" ]; then  
-    asset="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$releaseLine'")))[0].assets[0]')"
-    if [ $? -ne 0 ]; then
-      printError "Could not find release-line $releaseLine for repo $repo"
-    fi
-  elif [ ! "x" = "x$versioned" ]; then
+  # Options where the user explicitly sets a version/tag/releaseline currently ignore any configured release-line,
+  # either for a previous package install or system default
+  if [ ! "x" = "x$versioned" ]; then
     printVerbose "Specific version $versioned requested - checking existence and URL"
     requestedMajor=$(echo "$versioned" | awk -F'.' '{print $1}')
     requestedMinor=$(echo "$versioned" | awk -F'.' '{print $2}')
@@ -95,11 +103,14 @@ handlePackageInstall(){
     requestedSubrelease=$(echo "$versioned" | awk -F'.' '{print $4}')
     requestedVersion="${requestedMajor}\\\.${requestedMinor}\\\.${requestedPatch}\\\.${requestedSubrelease}"
     printVerbose "Finding URL for latest release matching version prefix: requestedVersion: $requestedVersion"
-    asset=$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.assets[].name | test("'$requestedVersion'")))[0].assets[0]')
+    releasemetadata=$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.assets[].name | test("'$requestedVersion'")))[0]')
   elif [ ! "x" = "x$tagged" ]; then
-    asset=$(/bin/printf "%s" "$releases" | jq -e -r '.[] | select(.tag_name == "'$tagged'").assets[0]')
+    printVerbose "Explicit tagger version '$tagged' specified. Checking for match"
+    releaseMetadata=$(/bin/printf "%s" "$releases" | jq -e -r '.[] | select(.tag_name == "'$tagged'")')
+    printVerbose "Use quick check for asset to check for existence of metadata for specific messages"
+    asset=$(/bin/printf "%s" "$releaseMetadata" | jq -e -r '.assets[0]')
     if [ $? -ne 0 ]; then
-      printError "Could not find tag $tagged for repo $repo"
+      printError "Could not find release tagged '$tagged' in repo '$repo'"
     fi
   elif $selectVersion; then
     # Explicitly allow the user to select a release to install; useful if there are broken installs
@@ -120,26 +131,94 @@ handlePackageInstall(){
         valid=true
       fi
     done
-    asset="$(/bin/printf "%s" "$releases" | jq -e -r ".[$selection].assets[0]")"
+    printVerbose "Selecting item $selection from array"
+    releaseMetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[$selection]")"
   elif [ ! -z "$releaseLine" ]; then  
-      asset="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$releaseLine'")))[0].assets[0]')"
-      if [ $? -ne 0 ]; then
-        printError "Could not find release-line $releaseLine for repo: $repo"
-      fi
-  else
-    printVerbose "No explicit version/tag/releaseline, checking for latest on system releaseline"
-    sysrelline=$(cat "$ZOPEN_ROOTFS/etc/zopen/releaseline" | awk ' {print toupper($1)}')
-    printVerbose "zopen system configured to use releaseline '$sysrelline'; checking for release..."
-    asset="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$sysrelline'")))[0].assets[0]')"
+    printVerbose "Install from release line '$releaseLine' specified"
+    validatedReleaseLine=$(validateReleaseLine "$releaseLine")
+    if [ -z "$validatedReleaseLine" ]; then
+      printError "Invalid releaseline specified: '$releaseLine'; Valid values: DEV or STABLE"
+    fi
+    printVerbose "Finding latest asset on the release line"
+    releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$releaseLine'")))[0]')"
+    printVerbose "Use quick check for asset to check for existence of metadata"
+    asset="$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')"
     if [ $? -ne 0 ]; then
-      printVerbose "Could not locate a specific release-line tagged version; installing latest"
-      asset="$(/bin/printf "%s" "$releases" | jq -e -r ".[0].assets[0]")"
+      printError "Could not find release-line $releaseLine for repo: $repo"
+    fi
+    
+  else
+set -x
+    printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
+    if [ -n $installedReleaseLine ]; then
+      printVerbose "Found existing releaseline '$installedReleaseLine', restricting to only that releaseline"
+      validatedReleaseLine="$installedReleaseLine"  # Already validated when stored
+    else 
+      sysrelline=$(cat "$ZOPEN_ROOTFS/etc/zopen/releaseline" | awk ' {print toupper($1)}')
+      printVerbose "Validating value: $sysrelline"
+      validatedReleaseLine=$(validateReleaseLine "$sysrelline")
+      if [ -z "$(validatedReleaseLine)" ]; then
+        printVerbose "zopen system configured to use releaseline '$sysrelline'; restricting to that releaseline"
+      else
+        printWarning "zopen misconfigured to use an unknown releaseline of '$sysrelline'; defaulting to STABLE packages"
+        printWarning "Set the contents of '$ZOPEN_ROOTFS/etc/zopen/releaseline' to a valid value to remove this message"
+        printWarning "Valid values are: DEV | STABLE"
+        validatedReleaseLine="STABLE"
+      fi
+    fi
+    # We have some situations that could arise
+      # 1. the port being installed has no releaseline tagging yet (ie. no releases tagged STABLE_* or DEV_*)
+      # 2. system is configured for STABLE but only has DEV stream available
+      # 3. system is configured for DEV but only has DEV stream available
+      # 4. the port being installed has got full releaseline tagging
+      # The issue could arise that the user has switched the system from DEV->STABLE or vice-versa so package
+      # stream mismatches could arise but in normal case, once a package is installed [that has releaseline tagging]
+      # then that specific releaseline will be used
+    printVerbose "Finding any releases tagged with $validatedReleaseLine and getting the first (newest/latest)"
+    releaseMetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$validatedReleaseLine'")))[0]')"
+    #releaseMetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | test("^$validatedReleaseLine"; "i")))[0]')"
+    printVerbose "Use quick check for asset to check for existence of metadata"
+    asset="$(/bin/printf "%s" "$releaseMetadata" | jq -e -r '.assets[0]')"
+    if [ $? -eq 0 ]; then
+      # Case 4...
+      printVerbose "Found a specific '$validatedReleaseLine' release-line tagged version; installing..."
+    else
+      # Case 2 & 3
+      printVerbose "No releases on releaseline '$validatedReleaseLine'; checking alternative releaseline"
+      alt=$(echo "$validatedReleaseLine" | awk ' /DEV/ { print "STABLE" } /STABLE/ { print "DEV" }')
+      releaseMetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | startswith("'$alt'")))[0]')"
+      #releaseMetadata="$(/bin/printf "%s" "$releases" | jq -e -r '. | map(select(.tag_name | test("^$alt"; "i")))[0]')"
+      printVerbose "Use quick check for asset to check for existence of metadata"
+      asset="$(/bin/printf "%s" "$releaseMetadata" | jq -e -r '.assets[0]')"
+      if [ $? -eq 0 ]; then
+        printVerbose "Found a release on the '$alt' release line so release tagging is active"
+        if [ "DEV" = "$validatedReleaseLine" ]; then
+          # The system will be configured to use DEV packages where available but if none, use latest
+          printInfo "No specific DEV releaseline package, using latest available"
+          releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
+        else
+          printVerbose "The system is configured to only use STABLE releaseline packages but there are none"
+          printInfo "No release available on the '$validatedReleaseLine' releaseline."
+        fi
+      else
+        # Case 1 - old package that has no release tagging yet (no DEV or STABLE), just install latest
+        printVerbose "Installing latest release"
+        releasemetadata="$(/bin/printf "%s" "$releases" | jq -e -r ".[0]")"
+      fi
     fi
   fi
 
+  printVerbose "Getting specific asset details from metadata: $releasemetadata"
+  if [ -z "$asset" ]; then
+    printVerbose "Asset not found during previous logic; setting now"
+    asset=$(/bin/printf "%s" "$releasemetadata" | jq -e -r '.assets[0]')
+  fi
   if [ "x" = "x$asset" ]; then
     printError "Unable to determine download asset for ${name}"
   fi
+
+  tagname=$(/bin/printf "%s" "$releasemetadata" | jq -e -r ".tag_name" | sed "s/\([^_]*\)_.*/\1/")
+  installedReleaseLine=$(validateReleaseLine "$tagname" )
 
   downloadURL=$(/bin/printf "%s" "$asset" | jq -e -r '.url')
   size=$(/bin/printf "%s" "$asset" | jq -e -r '.expanded_size')
@@ -207,7 +286,7 @@ handlePackageInstall(){
 
   pax=$downloadFile
   if [ -f "$pax" ]; then
-    printInfo "- Found existing file '${pax}'in ${location}"
+    printInfo "- Found existing file '${pax}' in ${location}"
   else
     printInfo "- Downloading $pax file from remote to ${location}..."
     if ! $verbose; then
@@ -302,6 +381,10 @@ handlePackageInstall(){
     if [ ! -f "${baseinstalldir}/$installdirname/.version" ]; then
       echo "$downloadFileVer" > "${baseinstalldir}/$installdirname/.version"
     fi
+
+    printVerbose "Adding releaseline '$installedReleaseLine' metadata to ${baseinstalldir}/$installdirname/.releaseline"
+    echo "$installedReleaseLine" > "${baseinstalldir}/$installdirname/.releaseline"
+
     if $setactive; then
       if ! $nosymlink; then
         mergeIntoSystem "$name" "${baseinstalldir}/$installdirname" "$ZOPEN_ROOTFS" 
@@ -418,10 +501,6 @@ while [ $# -gt 0 ]; do
       ;;
     "--cache-only")
       cacheOnly=true  # Download remote pax file to cache only (no install)
-      ;;
-    "--release-line")
-      shift
-      releaseLine=$(echo "$1" | awk '{print toupper($0)}')
       ;;
     "--release-line")
       shift

--- a/bin/lib/zopen-install
+++ b/bin/lib/zopen-install
@@ -148,7 +148,6 @@ handlePackageInstall(){
     fi
     
   else
-set -x
     printVerbose "No explicit version/tag/releaseline, checking for pre-existing package&releaseline"
     if [ -n $installedReleaseLine ]; then
       printVerbose "Found existing releaseline '$installedReleaseLine', restricting to only that releaseline"

--- a/bin/lib/zopen-query
+++ b/bin/lib/zopen-query
@@ -12,10 +12,9 @@ printSyntax()
   echo "Syntax: zopen-query [<option>]* [<package]*" >&2
   echo "  where <option> may be one or more of:" >&2
   echo "  --list: list all available z/OS Open Tools."  >&2
-  echo "  --remote-search: check for package in z/OS Open Tools repo" >&2
+  echo "  --remote-search: regex match package against available z/OS Open Tools" >&2
   echo "  -i : --installed: list install z/OS Open Tools." >&2
   echo " --upgradeable: list packages where an upgrade is available." >&2
-#TODO echo "  --provides: list the files that an installed package provides." >&2
   echo "  -wp : --whatprovides: which installed package provided a file." >&2
   echo "  -v: run in verbose mode." >&2
   echo "  -d | --details: include full details for listings." >&2
@@ -23,6 +22,24 @@ printSyntax()
   echo "  --no-version:  suppress version information, return package names." >&2
   echo "  --filter <color>: apply filter based on quality (green - all tests passing, blue - most tests passing, yellow - some tests passing, red - no tests passing, or skipped (no filter by default))"  >&2
   echo " and <package> is an optional list of one or more packages." >&2
+}
+
+colorizepct(){
+  percentage=$1
+  if [ -z "$percentage" ]; then
+    colored="${RED}"
+  elif [ ! "$percentage" = "${percentage#Skipped}" ]; then
+    colored="${RED}"
+  elif [ $percentage -eq 100 ]; then
+    colored="${GREEN}"
+  elif [ $percentage -gt 50 ]; then
+    colored="${BLUE}"
+  elif [ $percentage -gt 0 ]; then
+    colored="{YELLOW}"
+  else
+    colored="${RED}"
+  fi
+  echo "$colored"
 }
 
 printDetailListEntries()
@@ -35,11 +52,22 @@ printDetailListEntries()
     scrcols=$(getScreenCols)
     numcols=4
     colwidth=$(($scrcols / $numcols -1 ))
+    printVerbose "Screen width: $scrcols; colwidth:$colwidth"
     if [ ! -z "$1" ] && ! $noheader; then
-      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Installed" "Available" "Latest Tag"
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "Available" "Latest Tag"
     fi
     echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
-      if [ -z $needle ] || [ "${repo}" = "${needle}" ]; then
+      listport=false
+      if [ -z "$needle" ]; then
+        listport=true
+      else
+        printVerbose "Attempting regex find with needle: '$needle'"
+        if expr "$repo" : "$needle" 1>/dev/null; then
+          listport=true
+        fi
+      fi
+    
+      if $listport; then
         latest=$(jq -e -r '.release_data."'$repo'"[0]' "$JSON_CACHE")
         if [ $? -ne 0 ]; then
           printError "Unable to retrieve remote information"
@@ -72,11 +100,22 @@ printDetailListEntries()
     scrcols=$(getScreenCols)
     numcols=6
     colwidth=$(($scrcols / $numcols -1 ))
+    printVerbose "Screen width: $scrcols; colwidth:$colwidth"
     if ! $noheader; then
-      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Your version" "Latest Tag" "Download Size" "Expanded Size" "Quality"
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "Latest Tag" "Download Size" "Expanded Size" "Quality"
     fi
     echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
-      if [ -z $needle ] || [ "${repo}" = "${needle}" ]; then
+      listport=false
+      if [ -z "$needle" ]; then
+        listport=true
+      else
+        printVerbose "Attempting regex find with needle: '$needle'"
+        if expr "$repo" : "$needle" 1>/dev/null; then
+          listport=true
+        fi
+      fi
+    
+      if $listport; then
         if [ -e "${ZOPEN_PKGINSTALL}/${repo}/.releaseinfo" ]; then
           originalTag=$(cat "${ZOPEN_PKGINSTALL}/${repo}/.releaseinfo")
         else
@@ -102,19 +141,14 @@ printDetailListEntries()
                  percentage=$(echo "scale=0; 100 * ($passed) / $total" | bc)
                fi
                printf "%-${colwidth}s %-${colwidth}s %-${colwidth}s " "$repo" "$originalTag" "$latestTag" 
-               if [ -z "$percentage" ]; then
-                printf "${NC}${RED}%-${colwidth}s${NC}" "No tests"
-               elif [ $percentage -eq 100 ]; then
-                printf "${NC}${GREEN}%-${colwidth}s${NC}" "$percentage%"
-               elif [ $percentage -gt 50 ]; then
-                printf "${NC}${BLUE}%-${colwidth}s${NC}" "$percentage%"
-               elif [ $percentage -gt 0 ]; then
-                printf "${NC}${YELLOW}%-${colwidth}s${NC}" "$percentage%"
-               else
-                printf "${NC}${RED}%-${colwidth}s${NC}" "$percentage%"
-               fi
-               printf " %-${colwidth}s"  "$expandedsize"
                printf " %-${colwidth}s"  "$downloadsize"
+               printf " %-${colwidth}s"  "$expandedsize"
+
+               if [ -z "$percentage" ]; then
+                 printf "${NC}${RED}%-${colwidth}s${NC}" "No tests"
+               else
+                 printf "${NC}%s%-${colwidth}s${NC}" $(colorizepct "$percentage" ) "$percentage%"
+               fi
                printf "\n"
                ;;
           *) printError "Error $httpResponseCode while trying to retrieve latest repo release";;
@@ -128,14 +162,18 @@ printDetailListEntries()
 }
 printInstalledEntries(){
   scrcols=$(getScreenCols)
-  numcols=4
+  [ $details -eq 0 ] && numcols=4 || numcols=6
   colwidth=$(($scrcols / $numcols -1 ))
   printVerbose "Screen width: $scrcols; colwidth:$colwidth"
   if [ ! -z "$1" ] && ! $noheader; then
-    printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Installed" "File" "Releaseline"
+    if [ $details -eq 0 ]; then
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "File" "Releaseline"
+    else
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s${NC}\n" "Package" "Installed" "File" "Releaseline" "Expanded Size" "Quality"
+    fi
   fi
   printVerbose "Getting list of symlinks in the package install directory (that point to specific versions)"
-  installedPackages=$(zosfind . -type d \! -name . -prune -o -type l -print)
+  installedPackages=$(cd "$ZOPEN_PKGINSTALL" && zosfind . -type d \! -name . -prune -o -type l -print)
   printVerbose "Packages: $installedPackages"
   echo "$installedPackages" | xargs | tr ' ' '\n' | sort | while read repo; do
     pkghome="$ZOPEN_PKGINSTALL/${repo}"
@@ -161,43 +199,60 @@ printInstalledEntries(){
       dotversion="N/A"
     fi
 
+    releaseline=""
     if [ -e "${pkghome}/.releaseline" ]; then
       releaseline=$(cat "${pkghome}/.releaseline")
-    else
-      releaseline="N/A"
     fi
-
+    if [ -z "$releaseline" ]; then
+      releaseline="n/a"
+    fi
+  
     printVerbose "Original tag: $originalTag for repo: $repo"
     if [ -z "$1" ]; then
       printInfo "$originalTag"
     else
       fileversion="$( cd "$ZOPEN_PKGINSTALL/${repo}" >/dev/null 2>&1 && pwd -P | xargs basename)"
-      printf "%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n" "$reponame" "$dotversion" "$fileversion" "$releaseline"
+      printf "%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s" "$reponame" "$dotversion" "$fileversion" "$releaseline"
+      if [ $details -eq 1 ]; then
+        # Extra headers: disk size and quality
+        disksizestr=$(du "$ZOPEN_PKGINSTALL/${repo}" |tail -n 1 )
+        disksizestr=$(echo $disksizestr | sed 's#\([0-9]*\).*#\1#')
+        disksize=$(( $disksizestr * 512 ))
+        printf "%-${colwidth}d" $(( $disksizestr * 512 ))
+
+        if [ -e "${pkghome}/test.status" ]; then
+          teststatus=$(cat "${pkghome}/test.status")
+          percentage=$(echo "$teststatus" | sed 's/[^-]*-\([^%\.]*\).*/\1/')
+          printf "${NC}$s%-${colwidth}s${NC}" $(colorizepct "$percentage") "$percentage"
+        else
+           printf "${NC}${RED}%-${colwidth}s${NC}" "No tests"
+        fi
+      fi
+      
+      printf "\n"
     fi
   done
   exit 0
 }
 
-
 whatProvides(){
-  needle=$1
-  printVerbose "Finding matches outside the ZOPEN_PKGINSTALL ($ZOPEN_PKGINSTALL)"
-  # Find any symlinks that match the name and can then be dereferenced
-  found=$(zosfind $ZOPEN_ROOTFS/usr -type l | grep "${needle}")
-  printVerbose "Found? '$found'"
-  if [[ -z $found ]]; then
+  needle="$1"
+  printVerbose "Finding matches outside of ZOPEN_PKGINSTALL ($ZOPEN_PKGINSTALL)"
+  # Find any symlinks that match the needle and can then be dereferenced
+  found=$(zosfind "$ZOPEN_ROOTFS" -name "$ZOPEN_PKGINSTALL/\*" -prune -o -type l -print | grep "${needle}") 
+  printVerbose "Found list: '$found'"
+  if [[ -z "$found" ]]; then
     printInfo "No package provides '${needle}'"
   else
     matches=$(echo "$found"| wc -w | tr -d ' ' ) 
     printInfo "Found ${matches} match$([ $matches = 1 ] && echo "" || echo "es") for regex '${needle}' on the system"
     echo "$found" | xargs | tr ' ' '\n' | while read foundmatch; do
-      printVerbose "Parsing $foundmatch"
-      if [ ! -d $foundmatch ]; then
-        deref=$(ls -l $foundmatch | awk '{ print $(NF) }')
-        printVerbose "$ZOPEN_PKGINSTALL  -> $deref"
-        printVerbose "${deref#$ZOPEN_PKGINSTALL}"
-        pkg=$(echo "${deref#$ZOPEN_PKGINSTALL}" | awk -F/ '{print $2}')
-        printInfo "$pkg provides '$foundmatch'"
+      printVerbose "Parsing '$foundmatch'"
+      if [ ! -d "$foundmatch" ]; then
+      dereferenced=$(deref "$foundmatch")
+      fullpackage=$(echo "$dereferenced" | sed "s#$ZOPEN_PKGINSTALL/\([^/]*\).*#\1#")
+      
+      printInfo "Package '$fullpackage' provides: '$foundmatch'"
       fi
     done
   fi
@@ -294,45 +349,15 @@ if [ ! -z "$filter" ]; then
 fi
 
 if ! $localoption; then
-
- # Retrieve all repositories
- # TODO: These are causing early exists???
- # progressHandler "network" "- Retrieved remote details" &
- # ph=$!
- # killph="kill -HUP $ph"
- # addCleanupTrapCmd "$killph"
+  # Retrieve all repositories
   getReposFromGithub
   grfgRc=$?
-  $killph 2>/dev/null  # if the timer is not running, the kill will fail
   [ 0 -ne $grfgRc ] && exit $grfgRc;
-
-  # Parse repositories for zopen framework repos
-  foundPort=false
-  repoArray=""
-  for repo in $(echo ${repo_results}); do
-    repo=${repo#"ZOSOpenTools/"}
-    name=${repo%port}
-    printVerbose "Checking repo suffixes for '$repo' with name:'$name'"
-  
-    if [ -z "${chosenRepos}" ]; then
-      repoArray="$repoArray $repo"
-    else
-      printVerbose "Testing ${chosenRepos}"
-      for toolrepo in $(echo "${chosenRepos}" | tr ',' '\n'); do
-        if [ "${toolrepo}" = "${repo}" ] || [ "${toolrepo}" = "${name}" ]; then
-          # Skip if the repo does not end with port
-          if [ "${repo}" = "${name}" ]; then
-            continue;
-          fi
-          repoArray="$repoArray $repo"
-        fi
-      done
-    fi
-  done
+  repoArray="$repo_results"
 fi
 
 ! $upgradeable || printDetailListEntries $details "" 1
-[ -z "$remotesearch" ] || printDetailListEntries $details $needle 0
+[ -z "$remotesearch" ] || printDetailListEntries $details "$needle" 0
 [ -z "$list" ] || printDetailListEntries $details "" 0
 [ -z "$installed" ] || printInstalledEntries $details "" 0
-[ -z "$whatprovides" ] || whatProvides $needle
+[ -z "$whatprovides" ] || whatProvides "$needle"

--- a/bin/lib/zopen-query
+++ b/bin/lib/zopen-query
@@ -36,7 +36,7 @@ printDetailListEntries()
     numcols=4
     colwidth=$(($scrcols / $numcols -1 ))
     if [ ! -z "$1" ] && ! $noheader; then
-      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Your version" ".version" "Latest Tag"
+      printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Installed" "Available" "Latest Tag"
     fi
     echo "$repoArray" | xargs | tr ' ' '\n' | sort | while read repo; do
       if [ -z $needle ] || [ "${repo}" = "${needle}" ]; then
@@ -128,15 +128,28 @@ printDetailListEntries()
 }
 printInstalledEntries(){
   scrcols=$(getScreenCols)
-  numcols=3
+  numcols=4
   colwidth=$(($scrcols / $numcols -1 ))
+  printVerbose "Screen width: $scrcols; colwidth:$colwidth"
   if [ ! -z "$1" ] && ! $noheader; then
-    printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Installed version" "File version"
+    printf "${NC}${UNDERLINE}%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n${NC}" "Package" "Installed" "File" "Releaseline"
   fi
-  installedPackages="$(zosfind $ZOPEN_PKGINSTALL -name .active 2>/dev/null)"
+  printVerbose "Getting list of symlinks in the package install directory (that point to specific versions)"
+  installedPackages=$(zosfind . -type d \! -name . -prune -o -type l -print)
   printVerbose "Packages: $installedPackages"
   echo "$installedPackages" | xargs | tr ' ' '\n' | sort | while read repo; do
-    pkghome=$(dirname "${repo}")
+    pkghome="$ZOPEN_PKGINSTALL/${repo}"
+    if [ ! -e "${pkghome}/.active" ]; then
+      printVerbose "Symlink '$repo' in '$ZOPEN_PKGINSTALL' is not active; skipping"
+      continue
+    fi
+
+    reponame=$(echo "${repo#./}") 
+    if $noversions; then
+      printf "%s\n" "$reponame"
+      continue
+    fi
+
     if [ -e "${pkghome}/.releaseinfo" ]; then
       originalTag=$(cat "${pkghome}/.releaseinfo")
     else
@@ -148,17 +161,18 @@ printInstalledEntries(){
       dotversion="N/A"
     fi
 
+    if [ -e "${pkghome}/.releaseline" ]; then
+      releaseline=$(cat "${pkghome}/.releaseline")
+    else
+      releaseline="N/A"
+    fi
+
     printVerbose "Original tag: $originalTag for repo: $repo"
     if [ -z "$1" ]; then
       printInfo "$originalTag"
     else
-      fileversion="$( cd "$(dirname "$repo")" >/dev/null 2>&1 && pwd -P | xargs basename)"
-      reponame=$(dirname "$repo" | xargs basename)
-      if ! $noversions; then
-        printf "%-${colwidth}s %-${colwidth}s %-${colwidth}s\n" "$reponame" "$dotversion" "$fileversion"
-      else
-        printf "%s\n" "$reponame"
-      fi
+      fileversion="$( cd "$ZOPEN_PKGINSTALL/${repo}" >/dev/null 2>&1 && pwd -P | xargs basename)"
+      printf "%-${colwidth}s %-${colwidth}s %-${colwidth}s %-${colwidth}s\n" "$reponame" "$dotversion" "$fileversion" "$releaseline"
     fi
   done
   exit 0


### PR DESCRIPTION
Upgrading of packages within their releaseline; if installed with no releaseline or the package has no releaselines available, latest will be used.
Fixed package querying for above and added searching using regex:  zopen search .l[aA]m.*   should find llamacpp
Various other bug fixes to allow new code, remove redundant code, stabilize codebase and remove duplicated code from previous merge.
Resolves #53
