### PR TITLE
Use existing cacert.pem when run from

### DIFF
--- a/bin/lib/zopen-init
+++ b/bin/lib/zopen-init
@@ -219,7 +219,8 @@ if [ "$ZOPEN_PKGINSTALL" = "$rootfs" ]; then
    fi
 fi
 
-ZOPEN_CA_DIR="etc/pki/tls/certs"  # TODO: Work out "proper" location
+ZOPEN_CA_DIR="etc/pki/tls/certs"  # Mimic location on some Linux distributions
+certFileName="cacert.pem"
 if ! $clone; then
     printInfo "- Creating path for certificate lookups"
     [ -e "$rootfs/$ZOPEN_CA_DIR" ] || mkdir -p "$rootfs/$ZOPEN_CA_DIR"
@@ -230,7 +231,7 @@ echo "# z/OS Open Tools Configuration file" > "$configFile"
 echo "# Main root location for the zopen installation; can be changed if the " >> "$configFile"
 echo "# underlying root location is copied/moved elsewhere as locations are " >> "$configFile"
 echo "# relative to this envvar value" >> "$configFile"
-echo "ZOPEN_ROOTFS=$rootfs" >> "$configFile"
+echo "ZOPEN_ROOTFS=\"$rootfs\"" >> "$configFile"
 echo "export ZOPEN_ROOTFS" >> "$configFile"
 echo "configStartTime=\$SECONDS" >> "$configFile"
 echo "zot=\"z/OS Open Tools\"" >> "$configFile"
@@ -280,7 +281,7 @@ ZOPEN_PKGINSTALL=\$ZOPEN_ROOTFS/$zopen_pkginstall
 export ZOPEN_PKGINSTALL
 ZOPEN_SEARCH_PATH=\$ZOPEN_ROOTFS/usr/share/zopen/
 export ZOPEN_SEARCH_PATH
-ZOPEN_CA=\$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/cacert.pem
+ZOPEN_CA=\"\$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/$certFileName\"
 export ZOPEN_CA
 ZOPEN_LOG_PATH=\$ZOPEN_ROOTFS/var/log
 export ZOPEN_LOG_PATH
@@ -407,19 +408,29 @@ else
   [ -e "$cachedir/$basejqpax" ] || printError "Could not locate bootstrap jq pax."
   paxrc=$(pax -rf "$cachedir/$basejqpax" -s##$rootfs/boot/#)
 
-  cacertlcn=$(findrev "${utildir}" "cacert.pem")
-  if [ -e "$cacertlcn/cacert.pem" ]; then
-    printInfo "- Found default cacert.pem; copying to zopen file system"
-    cp -f "$cacertlcn/cacert.pem" "$ZOPEN_ROOTFS/$ZOPEN_CA_DIR"
+  if [ -n "$ZOPEN_CA" ]; then
+    printVerbose "Existing envvar for ZOPEN_CA found; running within a zopen environment"
+    if [ -r "$ZOPEN_CA" ]; then
+      printInfo "- Found existing setting for ZOPEN_CA '$ZOPEN_CA'; reusing certificate"
+      cp -f "$ZOPEN_CA" "$ZOPEN_ROOTFS/$ZOPEN_CA_DIR"
+    else
+      printError "Could not use certificate file '$certFileName' from ZOPEN_CA='$ZOPEN_CA'"
+    fi
   else
-    printError "Could not locate default cacert.pem at '../cacert.pem'."
+    printVerbose "Checking '${utildir}' directory tree for certificate file '$certFileName'"
+    cacertlcn="$(findrev "${utildir}" "$certFileName")"
+    if [ -e "$cacertlcn/$certFileName" ]; then
+      printInfo "- Found default certificate file '$certFileName'; copying to zopen file system"
+      cp -f "$cacertlcn/$certFileName" "$ZOPEN_ROOTFS/$ZOPEN_CA_DIR"
+    else
+      printError "Could not locate default certificate file '$certFileName' in directory structure above ${utildir}"
+    fi
   fi
-
-  if [ -r "$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/cacert.pem" ]; then
-    printInfo "- Setting certificate envvar"
-    export SSL_CERT_FILE="$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/cacert.pem"
+  if [ -r "$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/$certFileName" ]; then
+    printInfo "- Setting certificate environment variable"
+    export SSL_CERT_FILE="$ZOPEN_ROOTFS/$ZOPEN_CA_DIR/$certFileName"
   else
-    printError "- Could not locate cacert.pem at '$ZOPEN_ROOTFS/$ZOPEN_CA_DIR'"
+    printError "- Could not locate '$certFileName' in '$ZOPEN_ROOTFS/$ZOPEN_CA_DIR'"
   fi
   
   # Need to source the .env file from within the actual curl directory and cannot
@@ -446,6 +457,8 @@ else
   ZOPEN_CA="$ZOPEN_CA/cacert.pem"
   export ZOPEN_CA
   runAndLog "${utildir}/zopen-update-cacert -f"
+  [ $? -ne 0 ] && exit $?
+
   printInfo "- Sourcing environment"
   . "$configFile"
   printInfo "- Using bootstrapped curl and jq to install latest release of itself (if available)"

--- a/bin/lib/zopen-update-cacert
+++ b/bin/lib/zopen-update-cacert
@@ -5,7 +5,7 @@
 if [ -z "$utildir" ]; then
   export mydir="$( cd "$(dirname "$0")" >/dev/null 2>&1 && pwd -P )"
 else
-  mydir=$utildir
+  mydir="$utildir"
 fi
 
 . "${mydir}/common.inc"
@@ -17,7 +17,7 @@ fi
 # Temporary files
 for tmp in "$TMPDIR" "$TMP" /tmp
 do
-  if [ ! -z $tmp ] && [ -d $tmp ]; then
+  if [ ! -z "$tmp" ] && [ -d "$tmp" ]; then
     TEMP_CACERT="$tmp/$LOGNAME.$RANDOM.cacert.pem"
     break
   fi
@@ -25,7 +25,7 @@ done
 
 cleanupOnExit() {
     rv=$?
-    [ -f $TEMP_CACERT ] && rm -rf $TEMP_CACERT
+    [ -f "$TEMP_CACERT" ] && rm -rf "$TEMP_CACERT"
     exit $rv
 }
 
@@ -61,13 +61,16 @@ getCACertFromCurl()
       nocertverify="-k "
     fi
   fi
-  curlver="$(whence curl)"
-  printVerbose "Using curl located at: $curlver"
-  if ! $curlver -L $nocertverify -o "$TEMP_CACERT" ${cacert_update_url} ; then
+  curlver="$(type curl)"
+  crc=$?
+  [ $crc -ne 0 ] && printError "Could not locate curl to download certificate."
+
+  printVerbose "Type of curl: $curlver"
+  if ! curl -L "$nocertverify" -o "$TEMP_CACERT" ${cacert_update_url} ; then
     printError "curl command could not download from: ${cacert_update_url}"
   fi
 
-  if [ ! -f $TEMP_CACERT ]; then
+  if [ ! -f "$TEMP_CACERT" ]; then
     printError "$TEMP_CACERT was not downloaded"
   fi
 }
@@ -75,7 +78,7 @@ getCACertFromCurl()
 updateCACert()
 {
   printInfo "Re-creating $ZOPEN_CA"
-  cp "$TEMP_CACERT" $ZOPEN_CA
+  cp "$TEMP_CACERT" "$ZOPEN_CA"
 }
 
 # Main code start here
@@ -89,7 +92,7 @@ export cacert_update_url="https://curl.se/ca/cacert.pem"
 # Temporary files
 for tmp in "$TMPDIR" "$TMP" /tmp
 do
-  if [ ! -z $tmp ] && [ -d $tmp ]; then
+  if [ ! -z "$tmp" ] && [ -d "$tmp" ]; then
     TEMP_CACERT="$tmp/$LOGNAME.$RANDOM.cacert.pem"
     break
   fi
@@ -131,8 +134,6 @@ while [[ $# -gt 0 ]]; do
   shift;
 done
 
-#ZOPEN_CA="${dir}/cacert.pem"
-
 if ! [ -r "${ZOPEN_CA}" ]; then
   forceUpdate=true 
 fi
@@ -147,9 +148,9 @@ fi
 
 if $forceUpdate; then
   updateCACert
-elif ! diff "$TEMP_CACERT" $ZOPEN_CA >/dev/null; then
+elif ! diff "$TEMP_CACERT" "$ZOPEN_CA" >/dev/null; then
   while true; do
-    printWarning "Your local cacert ($ZOPEN_CA) is outdated or does not exist. Would you like to update it? (y, n)"
+    printWarning "Your local cacert '$ZOPEN_CA' is outdated or does not exist. Would you like to update it? (y, n)"
     update=$(getInput)
     if [ "$update" = "n" ]; then
       exit 0
@@ -160,5 +161,5 @@ elif ! diff "$TEMP_CACERT" $ZOPEN_CA >/dev/null; then
 
   updateCACert
 else
-  printInfo "Your cacert ($ZOPEN_CA) is already up to date"
+  printInfo "Your cacert '$ZOPEN_CA' is already up to date"
 fi


### PR DESCRIPTION
Resolve issue where running zopen init from within a zopen environment fails to locate the CA certificate.
Reuse the existing CA certificate from the current setup to initialize the new setup